### PR TITLE
Added Check.NotNull<T>() and refactored

### DIFF
--- a/src/ProtobufCompiler/Compiler/Source.cs
+++ b/src/ProtobufCompiler/Compiler/Source.cs
@@ -19,8 +19,7 @@ namespace ProtobufCompiler.Compiler
 
         internal Source(StreamReader streamReader)
         {
-            if(streamReader == null) throw new ArgumentNullException(nameof(streamReader));
-            _streamReader = streamReader;
+            _streamReader = Check.NotNull(streamReader, nameof(streamReader));
             Line = 1;
             Column = 0;
         }

--- a/src/ProtobufCompiler/Extensions/Check.cs
+++ b/src/ProtobufCompiler/Extensions/Check.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace ProtobufCompiler.Extensions
+{
+    internal static class Check
+    {
+        internal static T NotNull<T>(T value, string parameterName)
+        {
+            if (ReferenceEquals(value, null))
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentNullException(parameterName);
+            }
+
+            return value;
+        }
+
+        internal static string NotEmpty(string value, string parameterName)
+        {
+            if (ReferenceEquals(value, null))
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentException($"The string argument '{value}' cannot be empty.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/ProtobufCompiler/Types/EnumDefinition.cs
+++ b/src/ProtobufCompiler/Types/EnumDefinition.cs
@@ -4,6 +4,7 @@ using System.Linq;
 #if DNXCORE50
 using System.Globalization;
 #endif
+using ProtobufCompiler.Extensions;
 
 namespace ProtobufCompiler.Types
 {
@@ -20,9 +21,7 @@ namespace ProtobufCompiler.Types
 
         internal EnumDefinition(string name, IEnumerable<Option> option, IEnumerable<EnumField> fields)
         {
-            if(name == null) throw new ArgumentNullException(nameof(name));
-
-            Name = name;
+            Name = Check.NotNull(name, nameof(name));
             EnumOption = option ?? new List<Option>();
             EnumFields = fields ?? new List<EnumField>();
         }

--- a/src/ProtobufCompiler/Types/EnumField.cs
+++ b/src/ProtobufCompiler/Types/EnumField.cs
@@ -4,6 +4,7 @@ using System.Linq;
 #if DNXCORE50
 using System.Globalization;
 #endif
+using ProtobufCompiler.Extensions;
 
 namespace ProtobufCompiler.Types
 {
@@ -21,8 +22,7 @@ namespace ProtobufCompiler.Types
 
         internal EnumField(string name, int fieldNum, IEnumerable<Option> option)
         {
-            if(name == null) throw new ArgumentNullException(nameof(name));
-            Name = name;
+            Name = Check.NotNull(name, nameof(name));
             FieldNumber = fieldNum;
             FieldOptions = option ?? new List<Option>();
         }

--- a/src/ProtobufCompiler/Types/ServiceDefinition.cs
+++ b/src/ProtobufCompiler/Types/ServiceDefinition.cs
@@ -4,6 +4,7 @@ using System.Linq;
 #if DNXCORE50
 using System.Globalization;
 #endif
+using ProtobufCompiler.Extensions;
 
 namespace ProtobufCompiler.Types
 {
@@ -20,8 +21,7 @@ namespace ProtobufCompiler.Types
 
         internal ServiceDefinition(string name, IEnumerable<ServiceMethod> serviceMethods, IEnumerable<Option> serviceOptions )
         {
-            if(name == null) throw new ArgumentNullException(nameof(name));
-            Name = name;
+            Name = Check.NotNull(name, nameof(name));
             Methods = serviceMethods ?? new List<ServiceMethod>();
             Options = serviceOptions ?? new List<Option>();
         }

--- a/src/ProtobufCompiler/Types/ServiceMethod.cs
+++ b/src/ProtobufCompiler/Types/ServiceMethod.cs
@@ -2,6 +2,7 @@
 #if DNXCORE50
 using System.Globalization;
 #endif
+using ProtobufCompiler.Extensions;
 
 namespace ProtobufCompiler.Types
 {
@@ -18,13 +19,9 @@ namespace ProtobufCompiler.Types
 
         internal ServiceMethod(string name, ParameterType inputType, ParameterType outputType)
         {
-            if(name == null) throw new ArgumentNullException(nameof(name));
-            if(inputType == null) throw new ArgumentNullException(nameof(inputType));
-            if (outputType == null) throw new ArgumentNullException(nameof(outputType));
-
-            Name = name;
-            InputType = inputType;
-            OutputType = outputType;
+            Name = Check.NotNull(name, nameof(name));
+            InputType = Check.NotNull(inputType, nameof(inputType));
+            OutputType = Check.NotNull(outputType, nameof(outputType));
         }
 
         public bool Equals(ServiceMethod other)

--- a/src/ProtobufCompiler/project.json
+++ b/src/ProtobufCompiler/project.json
@@ -8,9 +8,11 @@
   "projectUrl": "https://github.com/draylundy/ProtobufGenerator",
   "licenseUrl": "https://raw.githubusercontent.com/draylundy/ProtobufGenerator/master/LICENSE",
 
-  "dependencies": {
-    
+  "compilationOptions": {
+    "warningsAsErrors": true
+  },
 
+  "dependencies": {
   },
 
   "frameworks": {

--- a/src/ProtobufGenerator/Extensions/Check.cs
+++ b/src/ProtobufGenerator/Extensions/Check.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace ProtobufGenerator.Extensions
+{
+    internal static class Check
+    {
+        internal static T NotNull<T>(T value, string parameterName)
+        {
+            if (ReferenceEquals(value, null))
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentNullException(parameterName);
+            }
+
+            return value;
+        }
+
+        internal static string NotEmpty(string value, string parameterName)
+        {
+            if (ReferenceEquals(value, null))
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                NotEmpty(parameterName, nameof(parameterName));
+                throw new ArgumentException($"The string argument '{value}' cannot be empty.");
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/ProtobufGenerator/ProtoEngine.cs
+++ b/src/ProtobufGenerator/ProtoEngine.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using ProtobufGenerator.Generation;
+using ProtobufGenerator.Extensions;
 
 namespace ProtobufGenerator
 {
@@ -13,7 +14,7 @@ namespace ProtobufGenerator
 
         public ProtoEngine(IConfiguration configuration)
         {
-            _config = configuration;
+            _config = Check.NotNull(configuration, nameof(configuration));
         }
 
         public void ProcessProto()

--- a/src/ProtobufGenerator/project.json
+++ b/src/ProtobufGenerator/project.json
@@ -8,6 +8,10 @@
   "projectUrl": "https://github.com/draylundy/ProtobufGenerator",
   "licenseUrl": "https://raw.githubusercontent.com/draylundy/ProtobufGenerator/master/LICENSE",
 
+  "compilationOptions": {
+    "warningsAsErrors": true
+  },
+
   "dependencies": {
     "FluentAssertions": "4.0.0", 
     "Newtonsoft.Json": "7.0.1"


### PR DESCRIPTION
Added some shared code. Could be convenient for future use. E.g. add all Extensions and other static methods here.

Got the idea from [here](https://github.com/aspnet/EntityFramework/tree/master/src/Shared)

Btw. I think we should reconsider namespace usage. It's kind of problematic since none of the packages share the same root namespace. One idea could be:
- Protobuf.Generator
- Protobuf.Compiler
- Protobuf.Utilities

But I would suggest something better, since Protobuf is clearly taken by Google implementation,